### PR TITLE
Fix installation command

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -25,6 +25,7 @@ $LDFLAGS << " -Wl,-rpath,#{File.join(PREFIX, "lib")}"
 
 FileUtils.cd(MARISA_ROOT) do
   sys "./configure --enable-sse3 --prefix='#{PREFIX}'"
+  sys "make"
   sys "make install"
 end
 


### PR DESCRIPTION
I found that I couldn't `bundle install` melisa gem because `make install` fails due to lack of dependecy files "libs/libmalisa.lai".

To fix this issue, the build script should run `make` explicitly before installation.

tested on my Mac OS X Yosemite.

Can you check and merge my fix? Thanks.
