### PR TITLE
Fix IntTrie when binary-encoded value could include FF

### DIFF
--- a/lib/melisa/bytes_trie.rb
+++ b/lib/melisa/bytes_trie.rb
@@ -74,7 +74,7 @@ module Melisa
     end
 
     def agent_key_value(agent)
-      unserialize_value(agent.key_str.split(@sep).last)
+      unserialize_value(agent.key_str.split(@sep, 2).last)
     end
   end
 end

--- a/spec/int_trie_spec.rb
+++ b/spec/int_trie_spec.rb
@@ -15,6 +15,11 @@ describe Melisa::IntTrie do
     expect(trie['five']).to eq 5
   end
 
+  it "sets and gets values when binary-encoded value has \\xFF" do
+    trie['with_ff'] = 15359
+    expect(trie['with_ff']).to eq 15359
+  end
+
   it "retreives many values by prefix" do
     trie.get_all('one').should =~ [1, 3]
   end


### PR DESCRIPTION
### Issues

When we set `IntTrie` a value that could have '\xFF', for example, `255`, it always return `nil` even when a key is searched correctly.
This is because it fails to `split` the key_value string during un-serialization.

This PR will fix this problem by setting the limit of splittings to `2`.
